### PR TITLE
New HashBuilder, NormalizedPath and more

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,4 @@ indent_size = 2
 indent_size = 4
 insert_final_newline = true
 charset = utf-8-bom
+end_of_line = crlf

--- a/Atom.Build/Program.cs
+++ b/Atom.Build/Program.cs
@@ -51,7 +51,7 @@ public static class Program
         var moduleFiles = Directory.GetFiles(modulePath);
 
         var codeFiles = moduleFiles.Where(f => Path.GetExtension(f) == ".cs").OrderBy(f => f).ToList();
-        var sourceHash = new HashBuilder().AddRange(codeFiles.Select(File.ReadAllText)).GetHash();
+        var sourceHash = new HashBuilder().Add(codeFiles.Select(File.ReadAllText)).GetHash();
 
         // normalize tags, if needed
         info.Tags = info.Tags.AsCommaList().ToCommaList();
@@ -69,6 +69,7 @@ public static class Program
 
             info.Version = upd.ToString();
             info.SourceHash = sourceHash;
+            info.ReleaseNotes = "???";
             updated = true;
         }
 

--- a/Atom.Build/Program.cs
+++ b/Atom.Build/Program.cs
@@ -51,7 +51,13 @@ public static class Program
         var moduleFiles = Directory.GetFiles(modulePath);
 
         var codeFiles = moduleFiles.Where(f => Path.GetExtension(f) == ".cs").OrderBy(f => f).ToList();
-        var sourceHash = new HashBuilder().Add(codeFiles.Select(File.ReadAllText)).GetHash();
+        var hashBuilder = new HashBuilder();
+        foreach (var file in codeFiles)
+        {
+            hashBuilder.Add(Path.GetFileName(file));
+            hashBuilder.Add(File.ReadAllText(file));
+        }
+        var sourceHash = hashBuilder.GetHash();
 
         // normalize tags, if needed
         info.Tags = info.Tags.AsCommaList().ToCommaList();

--- a/Atom.Tests/Atom.Tests.csproj
+++ b/Atom.Tests/Atom.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <Using Include="FluentAssertions" />
+    <Using Include="FluentAssertions.Extensions" />
     <Using Include="NUnit.Framework" />
     <Using Include="Atom.AWS" />
     <Using Include="Atom.Azure" />

--- a/Atom.Tests/Util/CheckTypeTest.cs
+++ b/Atom.Tests/Util/CheckTypeTest.cs
@@ -1,9 +1,19 @@
+﻿using System.Collections;
+
+// ReSharper disable ClassNeverInstantiated.Local
 namespace Atom.Tests.Util;
 
 public class CheckTypeTest
 {
-    private enum TestEnum
+    private enum TestEnum { }
+
+    private class ListOfInt : List<int> { }
+
+    private class ListOfSomething<T> : List<T> { }
+
+    private class ListOfUnknown : IEnumerable
     {
+        public IEnumerator GetEnumerator() => throw new NotImplementedException();
     }
 
     [Test]
@@ -45,7 +55,112 @@ public class CheckTypeTest
         CheckType.IsEnum<List<TestEnum?>>().Should().BeFalse();
 
         CheckType.IsEnum(typeof(object)).Should().BeFalse();
-        CheckType.IsEnum<TestEnum>().Should().BeTrue();
         CheckType.IsEnum(typeof(void)).Should().BeFalse();
+    }
+
+    [Test]
+    public void Check_Is_Enumerable_Of_Integer()
+    {
+        // ReSharper disable once InlineOutVariableDeclaration
+        Type itemType;
+
+        CheckType.IsEnumerableOf<int>(out _).Should().BeFalse();
+        CheckType.IsEnumerableOf<int?>(out _).Should().BeFalse();
+
+        CheckType.IsEnumerableOf<int[]>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int));
+        CheckType.IsEnumerableOf<int?[]>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int?));
+
+        CheckType.IsEnumerableOf<IEnumerable<int>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int));
+        CheckType.IsEnumerableOf<IEnumerable<int?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int?));
+
+        CheckType.IsEnumerableOf<List<int>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int));
+        CheckType.IsEnumerableOf<List<int?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int?));
+
+        CheckType.IsEnumerableOf<ListOfInt>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int));
+        CheckType.IsEnumerableOf<ListOfSomething<int>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int));
+        CheckType.IsEnumerableOf<ListOfSomething<int?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(int?));
+    }
+
+    [Test]
+    public void Check_Is_Enumerable_Of_String()
+    {
+        // ReSharper disable once InlineOutVariableDeclaration
+        Type itemType;
+
+        CheckType.IsEnumerableOf<string>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(char));
+        CheckType.IsEnumerableOf<string?>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(char));
+
+        CheckType.IsEnumerableOf<string[]>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+        CheckType.IsEnumerableOf<string?[]>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+
+        CheckType.IsEnumerableOf<IEnumerable<string>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+        CheckType.IsEnumerableOf<IEnumerable<string?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+
+        CheckType.IsEnumerableOf<List<string>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+        CheckType.IsEnumerableOf<List<string?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+
+        CheckType.IsEnumerableOf<ListOfSomething<string>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+        CheckType.IsEnumerableOf<ListOfSomething<string?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(string));
+    }
+
+    [Test]
+    public void Check_Is_Enumerable_Of_Object()
+    {
+        // ReSharper disable once InlineOutVariableDeclaration
+        Type itemType;
+
+        CheckType.IsEnumerableOf<object>(out _).Should().BeFalse();
+        CheckType.IsEnumerableOf<object?>(out _).Should().BeFalse();
+
+        CheckType.IsEnumerableOf<object[]>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+        CheckType.IsEnumerableOf<object?[]>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+
+        CheckType.IsEnumerableOf<IEnumerable<object>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+        CheckType.IsEnumerableOf<IEnumerable<object?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+
+        CheckType.IsEnumerableOf<List<object>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+        CheckType.IsEnumerableOf<List<object?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+
+        CheckType.IsEnumerableOf<ListOfSomething<object>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+        CheckType.IsEnumerableOf<ListOfSomething<object?>>(out itemType).Should().BeTrue();
+        itemType.Should().Be(typeof(object));
+    }
+
+    [Test]
+    public void Check_Is_Enumerable_Of_Other()
+    {
+        CheckType.IsEnumerableOf(typeof(IEnumerable), out _).Should().BeFalse();
+        CheckType.IsEnumerableOf(typeof(IEnumerable<>), out _).Should().BeFalse();
+        CheckType.IsEnumerableOf(typeof(ListOfUnknown), out _).Should().BeFalse();
+        CheckType.IsEnumerableOf(typeof(Array), out _).Should().BeFalse();
+        CheckType.IsEnumerableOf(typeof(List<>), out _).Should().BeFalse();
+        CheckType.IsEnumerableOf(typeof(object), out _).Should().BeFalse();
+        CheckType.IsEnumerableOf(typeof(void), out _).Should().BeFalse();
     }
 }

--- a/Atom.Tests/Util/HashBuilderTest.cs
+++ b/Atom.Tests/Util/HashBuilderTest.cs
@@ -1,0 +1,314 @@
+﻿namespace Atom.Tests.Util;
+
+public class HashBuilderTest
+{
+    [Test]
+    public void Basic_Test()
+    {
+        var num1 = 0;
+        int? num2 = null;
+        var str1 = "test";
+        string? str2 = null;
+        var day1 = DayOfWeek.Monday;
+        DayOfWeek? day2 = null;
+        var obj1 = new byte[] { 1, 2, 3 };
+        byte[]? obj2 = null;
+
+        new HashBuilder()
+            .Add(num1)
+            .Add(num2)
+            .Add(str1)
+            .Add(str2)
+            .Add((int)day1)
+            .Add((int?)day2)
+            .Add(obj1)
+            .Add(obj2)
+            .GetHash()
+            .Should().Be("{1e96e4a6-7760-eec5-5545-0afb31d4effe}");
+
+        new HashBuilder()
+            .AddMany(num1, num2, str1, str2, (int)day1, (int?)day2, obj1, obj2)
+            .GetHash()
+            .Should().Be("{1e96e4a6-7760-eec5-5545-0afb31d4effe}");
+    }
+
+    [Test]
+    public void List_Of_Nullables()
+    {
+        var list1 = new List<string?>
+        {
+            "test1",
+            null,
+            "test2"
+        };
+        new HashBuilder().Add(list1).GetHash().Should().Be("{9f21ab4a-8aef-efbc-fd70-fcb226a3a099}");
+
+        var list2 = new[] {
+            "test1",
+            null,
+            "test2"
+        };
+        new HashBuilder().Add(list2).GetHash().Should().Be("{9f21ab4a-8aef-efbc-fd70-fcb226a3a099}");
+    }
+
+    [Test]
+    public void Null_Values_Considered_Equal()
+    {
+        byte? a1 = null;
+        string? b1 = null;
+        byte[]? c1 = null;
+
+        var hash1 = new HashBuilder()
+            .Add(a1)
+            .Add(b1)
+            .Add(c1)
+            .GetHash();
+
+        long? a2 = null;
+        object? b2 = null;
+        DateTime? c2 = null;
+
+        var hash2 = new HashBuilder()
+            .Add(a2)
+            .Add(b2)
+            .Add(c2)
+            .GetHash();
+
+        hash2.Should().Be(hash1);
+    }
+
+    [Test]
+    public void Non_Null_Values_Considered_Equal()
+    {
+        byte a1 = 1;
+        byte? b1 = 2;
+        byte? c1 = null;
+
+        var hash1 = new HashBuilder()
+            .Add(a1)
+            .Add(b1)
+            .Add(c1)
+            .GetHash();
+
+        byte a2 = 1;
+        byte b2 = 2;
+        byte? c2 = null;
+
+        var hash2 = new HashBuilder()
+            .Add(a2)
+            .Add(b2)
+            .Add(c2)
+            .GetHash();
+
+        hash2.Should().Be(hash1);
+    }
+
+    [Test]
+    public void Can_Safely_Cast_To_Object()
+    {
+        byte a1 = 1;
+        byte? b1 = 2;
+        byte? c1 = null;
+
+        var hash1 = new HashBuilder()
+            .Add(a1)
+            .Add(b1)
+            .Add(c1)
+            .GetHash();
+
+        object a2 = a1;
+        object b2 = b1;
+        object? c2 = c1;
+
+        var hash2 = new HashBuilder()
+            .Add(a2)
+            .Add(b2)
+            .Add(c2)
+            .GetHash();
+
+        hash2.Should().Be(hash1);
+    }
+
+    [Test]
+    public void Avoid_Type_Confusion()
+    {
+        bool? a1 = false;
+        var b1 = true;
+        var c1 = false;
+
+        var hash1 = new HashBuilder()
+            .Add(a1)
+            .Add(b1)
+            .Add(c1)
+            .GetHash();
+
+        var a2 = true;
+        var b2 = false;
+        bool? c2 = false;
+
+        var hash2 = new HashBuilder()
+            .Add(a2)
+            .Add(b2)
+            .Add(c2)
+            .GetHash();
+
+        hash2.Should().NotBe(hash1);
+    }
+
+    [Test]
+    public void Avoid_Confusion_Between_Integer_Types()
+    {
+        var hash1 = new HashBuilder().Add((byte)0).GetHash();
+        var hash2 = new HashBuilder().Add((short)0).GetHash();
+        var hash3 = new HashBuilder().Add(0).GetHash();
+        var hash4 = new HashBuilder().Add((long)0).GetHash();
+        hash2.Should().NotBe(hash1);
+        hash3.Should().NotBe(hash2).And.NotBe(hash1);
+        hash4.Should().NotBe(hash3).And.NotBe(hash2).And.NotBe(hash1);
+    }
+
+    [Test]
+    public void Avoid_Confusion_Between_Floating_Types()
+    {
+        var hash1 = new HashBuilder().Add((float)0).GetHash();
+        var hash2 = new HashBuilder().Add((double)0).GetHash();
+        var hash3 = new HashBuilder().Add((decimal)0).GetHash();
+        hash2.Should().NotBe(hash1);
+        hash3.Should().NotBe(hash2).And.NotBe(hash1);
+    }
+
+    [Test]
+    public void Avoid_Confusion_Between_Null_And_False()
+    {
+        var hash1 = new HashBuilder().Add(null).Add(null).GetHash();
+        var hash2 = new HashBuilder().Add(false).Add(null).GetHash();
+        var hash3 = new HashBuilder().Add(null).Add(false).GetHash();
+        var hash4 = new HashBuilder().Add(false).Add(false).GetHash();
+        hash2.Should().NotBe(hash1);
+        hash3.Should().NotBe(hash2).And.NotBe(hash1);
+        hash4.Should().NotBe(hash3).And.NotBe(hash2).And.NotBe(hash1);
+
+        hash1 = new HashBuilder().Add(new bool?[] { null, null }).GetHash();
+        hash2 = new HashBuilder().Add(new bool?[] { false, null }).GetHash();
+        hash3 = new HashBuilder().Add(new bool?[] { null, false }).GetHash();
+        hash4 = new HashBuilder().Add(new bool?[] { false, false }).GetHash();
+        hash2.Should().NotBe(hash1);
+        hash3.Should().NotBe(hash2).And.NotBe(hash1);
+        hash4.Should().NotBe(hash3).And.NotBe(hash2).And.NotBe(hash1);
+    }
+
+    [Test]
+    public void Avoid_Confusion_Between_List_And_Many_Items()
+    {
+        var hash1 = new HashBuilder().Add(1).Add(2).Add(3).GetHash();
+        var hash2 = new HashBuilder().AddMany(1, 2, 3).GetHash();
+        hash2.Should().Be(hash1);
+
+        var hash3 = new HashBuilder().Add(new[] { 1, 2, 3 }).GetHash();
+        hash3.Should().NotBe(hash2);
+
+        var hash4 = new HashBuilder().AddMany(new[] { 1, 2, 3 }).GetHash();
+        hash4.Should().Be(hash3);
+    }
+
+    [Test]
+    public void Avoid_Confusion_Between_List_And_Single_Item()
+    {
+        var hash1 = new HashBuilder().Add(1).GetHash();
+        var hash2 = new HashBuilder().Add(new[] { 1 }).GetHash();
+        hash2.Should().NotBe(hash1);
+    }
+
+    [Test]
+    public void Data_Type_Null()
+    {
+        new HashBuilder().Add(null).GetHash().Should().Be("{ad85b893-0dfe-89a0-cdf6-34904fd59f71}");
+    }
+
+    [Test]
+    public void Data_Type_Boolean()
+    {
+        new HashBuilder().Add(false).GetHash().Should().Be("{fb71a730-c283-00f5-0a74-d41689f19c76}");
+        new HashBuilder().Add(true).GetHash().Should().Be("{2f80e901-06d9-1a34-2b76-9125c562d95c}");
+    }
+
+    [Test]
+    public void Data_Type_Byte()
+    {
+        new HashBuilder().Add(Byte.MinValue).GetHash().Should().Be("{d050dc37-3c20-baa1-9548-ad9a28769fd2}");
+        new HashBuilder().Add((byte)0).GetHash().Should().Be("{d050dc37-3c20-baa1-9548-ad9a28769fd2}");
+        new HashBuilder().Add(Byte.MaxValue).GetHash().Should().Be("{70091737-fae3-afbd-3b88-d3536255fb42}");
+    }
+
+    [Test]
+    public void Data_Type_Int16()
+    {
+        new HashBuilder().Add(Int16.MinValue).GetHash().Should().Be("{4cbaa955-1fce-bfe6-8f7b-d9742ba5f952}");
+        new HashBuilder().Add((short)0).GetHash().Should().Be("{98aecfed-4095-42fd-e4b8-556d5b723bb6}");
+        new HashBuilder().Add(Int16.MaxValue).GetHash().Should().Be("{20cb7225-aa7b-1998-9405-a992700877c4}");
+    }
+
+    [Test]
+    public void Data_Type_Int32()
+    {
+        new HashBuilder().Add(Int32.MinValue).GetHash().Should().Be("{6eae6dc5-5253-0d8e-2f2c-7edfab01b091}");
+        new HashBuilder().Add(0).GetHash().Should().Be("{c4dbdd47-b2b3-b712-24fc-ff9aa02cbdcd}");
+        new HashBuilder().Add(Int32.MaxValue).GetHash().Should().Be("{5864836c-d573-20e4-9a22-d25313e34250}");
+    }
+
+    [Test]
+    public void Data_Type_Int64()
+    {
+        new HashBuilder().Add(Int64.MinValue).GetHash().Should().Be("{ba9a551b-1b61-f47d-d8a9-61687ce07ef3}");
+        new HashBuilder().Add((long)0).GetHash().Should().Be("{40c89733-076d-a33b-d205-5d39323d26ad}");
+        new HashBuilder().Add(Int64.MaxValue).GetHash().Should().Be("{0263e572-b0a9-2e48-04a3-fec03e6f2bb8}");
+    }
+
+    [Test]
+    public void Data_Type_Single()
+    {
+        new HashBuilder().Add(Single.MinValue).GetHash().Should().Be("{68030906-144a-df48-4068-eb82a3580bab}");
+        new HashBuilder().Add((float)0).GetHash().Should().Be("{b95ce10e-da30-2e51-9cca-c2b353f65d3f}");
+        new HashBuilder().Add(Single.MaxValue).GetHash().Should().Be("{ac890e3c-180a-a7ec-1e0b-15ca2ec805e7}");
+    }
+
+    [Test]
+    public void Data_Type_Double()
+    {
+        new HashBuilder().Add(Double.MinValue).GetHash().Should().Be("{cb411e34-eef6-f738-b048-6add0e2f24d9}");
+        new HashBuilder().Add((double)0).GetHash().Should().Be("{10e35e5a-10e9-a25f-be3e-3bc05b4f8aa1}");
+        new HashBuilder().Add(Double.MaxValue).GetHash().Should().Be("{6fc8e29e-faa8-12c3-586c-8d54049d192f}");
+    }
+
+    [Test]
+    public void Data_Type_Decimal()
+    {
+        new HashBuilder().Add(Decimal.MinValue).GetHash().Should().Be("{0d4289e8-c117-b024-3238-988776a8611c}");
+        new HashBuilder().Add((decimal)0).GetHash().Should().Be("{db03488c-18d7-6c68-7fe2-6bcd08b3c575}");
+        new HashBuilder().Add(Decimal.MaxValue).GetHash().Should().Be("{b4b71579-4be1-c7ee-6636-9b787bb329e3}");
+    }
+
+    [Test]
+    public void Data_Type_String()
+    {
+        new HashBuilder().Add(String.Empty).GetHash().Should().Be("{d685a40d-cc27-ecff-45b5-1b91fab8055a}");
+        new HashBuilder().Add("🙂").GetHash().Should().Be("{c14500c1-a2f7-79f3-3da1-1e6866c09264}");
+        new HashBuilder().Add("Hello").GetHash().Should().Be("{f042785e-dc59-97e6-4fa7-f78a5d64858b}");
+    }
+
+    [Test]
+    public void Data_Type_Unknown()
+    {
+        this.Invoking(_ => new HashBuilder().Add(new object()).GetHash())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Hashing is not supported for type 'Object', use standard .NET types or collections.");
+
+        this.Invoking(_ => new HashBuilder().Add(new Exception()).GetHash())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Hashing is not supported for type 'Exception', use standard .NET types or collections.");
+
+        this.Invoking(_ => new HashBuilder().Add(new List<Exception>()).GetHash())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Hashing is not supported for type 'Exception', use standard .NET types or collections.");
+    }
+}

--- a/Atom.Tests/Util/HashBuilderTest.cs
+++ b/Atom.Tests/Util/HashBuilderTest.cs
@@ -33,6 +33,32 @@ public class HashBuilderTest
     }
 
     [Test]
+    public void Basic_Byte_Arrays()
+    {
+        var data1 = new byte[] { 1, 2, 3, 4, 5 };
+        var hash11 = new HashBuilder().Add(data1).GetHash();
+        var hash12 = new HashBuilder().AddMany(data1).GetHash();
+        var hash13 = new HashBuilder().Add(data1).Add(data1).GetHash();
+        var hash14 = new HashBuilder().AddMany(data1, data1).GetHash();
+
+        hash11.Should().Be("{60705137-f215-8b43-2322-8d5c87fd4ae8}");
+        hash12.Should().Be("{60705137-f215-8b43-2322-8d5c87fd4ae8}");
+        hash13.Should().Be("{ce6128b4-a23b-e40d-fa5e-6fe912b6b90c}");
+        hash14.Should().Be("{ce6128b4-a23b-e40d-fa5e-6fe912b6b90c}");
+
+        var data2 = new byte?[] { 1, 2, 3, 4, 5 };
+        var hash21 = new HashBuilder().Add(data2).GetHash();
+        var hash22 = new HashBuilder().AddMany(data2).GetHash();
+        var hash23 = new HashBuilder().Add(data2).Add(data2).GetHash();
+        var hash24 = new HashBuilder().AddMany(data2, data2).GetHash();
+
+        hash21.Should().Be(hash11);
+        hash22.Should().Be(hash12);
+        hash23.Should().Be(hash13);
+        hash24.Should().Be(hash14);
+    }
+
+    [Test]
     public void List_Of_Nullables()
     {
         var list1 = new List<string?>
@@ -294,6 +320,81 @@ public class HashBuilderTest
         new HashBuilder().Add(String.Empty).GetHash().Should().Be("{d685a40d-cc27-ecff-45b5-1b91fab8055a}");
         new HashBuilder().Add("🙂").GetHash().Should().Be("{c14500c1-a2f7-79f3-3da1-1e6866c09264}");
         new HashBuilder().Add("Hello").GetHash().Should().Be("{f042785e-dc59-97e6-4fa7-f78a5d64858b}");
+    }
+
+    [Test]
+    public void Data_Type_Guid()
+    {
+        new HashBuilder().Add(Guid.Empty).GetHash().Should().Be("{3b9f8da1-04fa-3f87-631f-23e1cc935adc}");
+        new HashBuilder().Add(new Guid("{e3e39c20-1400-4bf9-8307-ee5f36c61cce}")).GetHash().Should().Be("{f3fd0866-e251-408a-ce6f-167c7d01b15b}");
+        new HashBuilder().Add(new Guid("{ffffffff-ffff-ffff-ffff-ffffffffffff}")).GetHash().Should().Be("{c779e7c4-7592-e2a5-b755-b1bd41295531}");
+    }
+
+    [Test]
+    public void Data_Type_DateTime()
+    {
+        new HashBuilder().Add(DateTime.MinValue).GetHash().Should().Be("{0d77b4b1-3b42-2cc2-82e3-dbcaa26b86e5}");
+        new HashBuilder().Add(DateTime.MaxValue).GetHash().Should().Be("{c6d96a5e-e399-b8a6-f439-28327f24257b}");
+
+        var date1 = 25.May(1983);
+        date1.Kind.Should().Be(DateTimeKind.Unspecified);
+        date1.TimeOfDay.Should().Be(TimeSpan.Zero);
+        new HashBuilder().Add(date1).GetHash().Should().Be("{a760d47c-73fd-bdea-5a39-d39aad24ca7f}");
+
+        var date2 = date1.ToLocalTime();
+        date2.Kind.Should().Be(DateTimeKind.Local);
+        date2.TimeOfDay.Should().NotBe(date1.TimeOfDay);
+        new HashBuilder().Add(date2).GetHash().Should().Be("{8f243170-d7ff-3c41-358c-bc164d5a4c33}");
+
+        var date3 = DateTime.SpecifyKind(date2, DateTimeKind.Utc);
+        date3.Kind.Should().Be(DateTimeKind.Utc);
+        date3.TimeOfDay.Should().Be(date2.TimeOfDay);
+        new HashBuilder().Add(date3).GetHash().Should().Be("{8f243170-d7ff-3c41-358c-bc164d5a4c33}");
+    }
+
+    [Test]
+    public void Data_Type_TimeSpan()
+    {
+        new HashBuilder().Add(TimeSpan.MinValue).GetHash().Should().Be("{0b9339dc-0c45-a443-bd53-f504248e1029}");
+        new HashBuilder().Add(TimeSpan.Zero).GetHash().Should().Be("{d9f9fdeb-cc45-f9e4-8442-5d06fa540f5f}");
+        new HashBuilder().Add(TimeSpan.MaxValue).GetHash().Should().Be("{c07868be-127d-7f8a-b7a5-b8485d208eec}");
+    }
+
+    [Test]
+    public void Data_Type_DateTimeOffset()
+    {
+        new HashBuilder().Add(DateTimeOffset.MinValue).GetHash().Should().Be("{504247b8-9246-3de2-7d78-53cf3a77addf}");
+        new HashBuilder().Add(DateTimeOffset.MaxValue).GetHash().Should().Be("{f04fdc3d-22ad-da5d-252b-16c9a073b1c6}");
+
+        var date1 = new DateTimeOffset(25.May(1983), TimeSpan.Zero);
+        date1.TimeOfDay.Should().Be(TimeSpan.Zero);
+        new HashBuilder().Add(date1).GetHash().Should().Be("{f2135d49-30be-48b7-892e-b1325417c130}");
+
+        var date2 = date1.ToLocalTime();
+        date2.TimeOfDay.Should().NotBe(date1.TimeOfDay);
+        new HashBuilder().Add(date2).GetHash().Should().Be("{0d0b8811-50e0-27a7-93b9-2bb9115a2280}");
+
+        var date3 = date1.ToUniversalTime();
+        date3.TimeOfDay.Should().Be(date1.TimeOfDay);
+        new HashBuilder().Add(date3).GetHash().Should().Be("{f2135d49-30be-48b7-892e-b1325417c130}");
+    }
+
+    [Test]
+    public void Data_Type_DateOnly()
+    {
+        new HashBuilder().Add(DateOnly.MinValue).GetHash().Should().Be("{a6ea7fdf-5697-afc6-c3e3-53e7a0ee139a}");
+        new HashBuilder().Add(DateOnly.MaxValue).GetHash().Should().Be("{713fab53-4611-cc10-d5b1-a5fcd9204b30}");
+
+        var date = new DateOnly(1983, 5, 25);
+        new HashBuilder().Add(date).GetHash().Should().Be("{47a85899-1d94-1bc3-a367-097b9216cf64}");
+    }
+
+    [Test]
+    public void Data_Type_TimeOnly()
+    {
+        new HashBuilder().Add(TimeOnly.MinValue).GetHash().Should().Be("{abe11b52-2c1b-08cd-8b0e-dec4c52469bb}");
+        new HashBuilder().Add(TimeOnly.Parse("12:34")).GetHash().Should().Be("{05f5112f-2bac-73ea-0072-8ce0c890650a}");
+        new HashBuilder().Add(TimeOnly.MaxValue).GetHash().Should().Be("{e9eb33dc-dcb0-5d8b-a73f-290d02feb498}");
     }
 
     [Test]

--- a/Atom.Tests/Util/NormalizedPathTest.cs
+++ b/Atom.Tests/Util/NormalizedPathTest.cs
@@ -1,0 +1,190 @@
+﻿namespace Atom.Tests.Util;
+
+public class NormalizedPathTest
+{
+    [Test]
+    public void Basic_Properties()
+    {
+        var dir = new NormalizedPath("/MyDirectory/");
+        dir.IsDirectory.Should().BeTrue();
+        dir.IsRoot.Should().BeFalse();
+        dir.RawPath.Should().Be("/MyDirectory/");
+        dir.InnerPath.Should().Be("MyDirectory");
+
+        var file = new NormalizedPath("/MyDirectory/MyFile.txt");
+        file.IsDirectory.Should().BeFalse();
+        file.IsRoot.Should().BeFalse();
+        file.RawPath.Should().Be("/MyDirectory/MyFile.txt");
+        file.InnerPath.Should().Be("MyDirectory/MyFile.txt");
+    }
+
+    [Test]
+    public void Root_Path()
+    {
+        NormalizedPath.Root.RawPath.Should().Be("/");
+        NormalizedPath.Root.InnerPath.Should().Be(String.Empty);
+        NormalizedPath.Root.IsRoot.Should().BeTrue();
+        NormalizedPath.Root.IsDirectory.Should().BeTrue();
+
+        NormalizedPath.Root.Should().Be("/");
+        NormalizedPath.Root.GetParent().Should().Be("/");
+
+        NormalizedPath.New().Should().Be(NormalizedPath.Root);
+    }
+
+    [Test]
+    public void Throws_If_Value_Is_Null()
+    {
+        this.Invoking(_ => new NormalizedPath(null!))
+            .Should().Throw<ArgumentNullException>()
+            .WithMessage("Value cannot be null. (Parameter 'path')")
+            .And.ParamName.Should().Be("path");
+    }
+
+    [TestCase("", true)]
+    [TestCase(" ", true)]
+    [TestCase(" /", true)]
+    [TestCase("/ ", false)]
+    [TestCase(" / ", true)]
+    public void Throws_If_Value_Does_Not_Start_With_Slash(string path, bool error)
+    {
+        if (error)
+        {
+            this.Invoking(_ => new NormalizedPath(path))
+                .Should().Throw<ArgumentException>()
+                .WithMessage($"Path '{path}' is expected to start with '/'.*")
+                .And.ParamName.Should().Be("path");
+        }
+        else
+        {
+            this.Invoking(_ => new NormalizedPath(path)).Should().NotThrow();
+        }
+    }
+
+    [TestCase("//", "//")]
+    [TestCase("/ /", null)]
+    [TestCase("/ / ", null)]
+    [TestCase("//", "//")]
+    [TestCase("// ", "//")]
+    [TestCase("//MyDirectory/", "//")]
+    [TestCase("/MyDirectory//", "//")]
+    [TestCase("/MyDirectory//MyFile.txt", "//")]
+    [TestCase("/Path\\", "\\")]
+    [TestCase("/Path:", ":")]
+    [TestCase("/Path*", "*")]
+    [TestCase("/Path?", "?")]
+    [TestCase("/Path\"", "\"")]
+    [TestCase("/Path<", "<")]
+    [TestCase("/Path>", ">")]
+    [TestCase("/Path|", "|")]
+    public void Throws_If_Value_Contains_Invalid_Characters(string path, string? invalid)
+    {
+        if (invalid != null)
+        {
+            this.Invoking(_ => new NormalizedPath(path))
+                .Should().Throw<ArgumentException>()
+                .WithMessage($"Path '{path}' is not expected to contain '{invalid}'.*")
+                .And.ParamName.Should().Be("path");
+        }
+        else
+        {
+            this.Invoking(_ => new NormalizedPath(path)).Should().NotThrow();
+        }
+    }
+
+    [TestCase("/", "/")]
+    [TestCase("/MyDirectory/", "/")]
+    [TestCase("/MyFile", "/")]
+    [TestCase("/MyDirectory/MyFile.txt", "/MyDirectory/")]
+    [TestCase("/MyDirectory/SubDir/", "/MyDirectory/")]
+    [TestCase("/MyDirectory/SubDir/MyFile.txt", "/MyDirectory/SubDir/")]
+    public void Get_Parent(string path, string parent)
+    {
+        new NormalizedPath(path).GetParent().Should().Be(parent);
+    }
+
+    [Test]
+    public void Append_Directory()
+    {
+        NormalizedPath.New()
+            .AppendDirectory("MyDirectory")
+            .AppendDirectory("SubDir")
+            .Should().Be("/MyDirectory/SubDir/");
+
+        NormalizedPath.New()
+            .AppendDirectory("/A")
+            .AppendDirectory("//B")
+            .AppendDirectory("C/")
+            .AppendDirectory("D//")
+            .AppendDirectory("///E///")
+            .Should().Be("/A/B/C/D/E/");
+
+        NormalizedPath.New("/A/B/")
+            .AppendDirectory("/C/D/E")
+            .Should().Be("/A/B/C/D/E/");
+
+        this.Invoking(_ => new NormalizedPath(NormalizedPath.New("/MyFile.txt").AppendDirectory("A")))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This method can only be used for paths that represent a directory, but the '/MyFile.txt' does not.");
+    }
+
+    [Test]
+    public void Append_File()
+    {
+        NormalizedPath.New()
+            .AppendDirectory("MyDirectory")
+            .AppendFile("MyFile.txt")
+            .Should().Be("/MyDirectory/MyFile.txt");
+
+        NormalizedPath.New().AppendDirectory("/A").AppendFile("B").Should().Be("/A/B");
+        NormalizedPath.New().AppendDirectory("/A").AppendFile("/B").Should().Be("/A/B");
+        NormalizedPath.New().AppendDirectory("/A").AppendFile("//B").Should().Be("/A/B");
+        NormalizedPath.New().AppendDirectory("/A").AppendFile("///B").Should().Be("/A/B");
+
+        NormalizedPath.New("/A/B/")
+            .AppendFile("/C/D/E")
+            .Should().Be("/A/B/C/D/E");
+
+        this.Invoking(_ => new NormalizedPath(NormalizedPath.New("/MyFile.txt").AppendFile("A")))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This method can only be used for paths that represent a directory, but the '/MyFile.txt' does not.");
+
+        this.Invoking(_ => new NormalizedPath(NormalizedPath.New().AppendFile("A/")))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("The provided value 'A/' more looks like a directory rather than file name. (Parameter 'fileName')")
+            .And.ParamName.Should().Be("fileName");
+
+        this.Invoking(_ => new NormalizedPath(NormalizedPath.New().AppendFile("A/B/")))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("The provided value 'A/B/' more looks like a directory rather than file name. (Parameter 'fileName')")
+            .And.ParamName.Should().Be("fileName");
+    }
+
+    [Test]
+    public void Can_Use_Conversions()
+    {
+        NormalizedPath path1 = "/MyDirectory/MyFile.txt";
+        path1.RawPath.Should().Be("/MyDirectory/MyFile.txt");
+
+        string path2 = new NormalizedPath("/MyDirectory/MyFile.txt");
+        path2.Should().Be("/MyDirectory/MyFile.txt");
+    }
+
+    [Test]
+    public void Can_Apply_Sort()
+    {
+        var paths = new NormalizedPath[] {
+            "/B/C.txt",
+            "/A/B/C.txt",
+            "/A/B.txt",
+            "/A.txt"
+        };
+
+        paths.OrderBy(p => p).Should().Equal(
+            new NormalizedPath("/A.txt"),
+            new NormalizedPath("/A/B.txt"),
+            new NormalizedPath("/A/B/C.txt"),
+            new NormalizedPath("/B/C.txt")
+        );
+    }
+}

--- a/Atom/Atom.csproj
+++ b/Atom/Atom.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Atom/Atom.csproj.DotSettings
+++ b/Atom/Atom.csproj.DotSettings
@@ -10,6 +10,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=util_005Cchecktype/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=util_005Ccommalist/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=util_005Chashbuilder/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=util_005Cnormalizedpath/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=util_005Cparse/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=util_005Cpathutil/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=util_005Crunprocess/@EntryIndexedValue">True</s:Boolean>

--- a/Atom/Util/CheckType/Atom.CheckType.nuspec
+++ b/Atom/Util/CheckType/Atom.CheckType.nuspec
@@ -2,10 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Atom.CheckType</id>
-    <version>1.2.0</version>
-    <releaseNotes>GetKeyword&lt;T&gt;() was moved to a different module named Atom.TypeName.</releaseNotes>
-    <tags>atom, util, check, type, nullable, enum</tags>
-    <description>Checks multiple criteria for built-in .NET types (is nullable, is enum, etc.)
+    <version>1.3.0</version>
+    <releaseNotes>Added IsEnumerableOf() method.</releaseNotes>
+    <tags>atom, util, check, type, nullable, enum, enumerable</tags>
+    <description>Provides various checks for built-in .NET types (is nullable, is enum, is enumerable etc.)
 
 Add this package to your core library, so it would get the source code of this module without installing a binary dependency. Then proceed with using corresponding functionality from Atom.Util namespace, like if it was installed using binary assembly.
 

--- a/Atom/Util/CheckType/Atom.CheckType.nuspec
+++ b/Atom/Util/CheckType/Atom.CheckType.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Atom.CheckType</id>
     <version>1.3.0</version>
-    <releaseNotes>Added IsEnumerableOf() method.</releaseNotes>
+    <releaseNotes>Added IsEnumerableOf&lt;T&gt;() method.</releaseNotes>
     <tags>atom, util, check, type, nullable, enum, enumerable</tags>
     <description>Provides various checks for built-in .NET types (is nullable, is enum, is enumerable etc.)
 

--- a/Atom/Util/CheckType/CheckType.cs
+++ b/Atom/Util/CheckType/CheckType.cs
@@ -1,4 +1,8 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
 
 namespace Atom.Util
 {
@@ -48,6 +52,34 @@ namespace Atom.Util
 
             // regular enum
             return type.IsEnum;
+        }
+
+        /// <summary>
+        /// Checks if specified type is enumerable over some specific type,
+        /// i.e. inherits <see cref="IEnumerable{T}"/>.
+        /// Also returns the underlying item type.
+        /// </summary>
+        public static bool IsEnumerableOf<T>(out Type itemType) => IsEnumerableOf(typeof(T), out itemType);
+
+        /// <summary>
+        /// Checks if specified type is enumerable over some specific type,
+        /// i.e. inherits <see cref="IEnumerable{T}"/>.
+        /// Also returns the underlying item type.
+        /// </summary>
+        public static bool IsEnumerableOf(Type type, out Type itemType)
+        {
+            var checkInterface = type.GetInterfaces().Append(type)
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+            if (checkInterface != null)
+            {
+                itemType = checkInterface.GetGenericArguments()[0];
+                if (!itemType.IsGenericParameter)
+                    return true;
+            }
+
+            itemType = typeof(void);
+            return false;
         }
     }
 }

--- a/Atom/Util/HashBuilder/Atom.HashBuilder.nuspec
+++ b/Atom/Util/HashBuilder/Atom.HashBuilder.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Atom.HashBuilder</id>
-    <version>1.0.3</version>
-    <releaseNotes>???</releaseNotes>
+    <version>1.1.0</version>
+    <releaseNotes>New hashing algorithm that considers data types, nullability and avoids collisions.</releaseNotes>
     <tags>atom, util, hash, md5, crc</tags>
     <description>Builds MD5 hash for a combination of standard .NET types.
 

--- a/Atom/Util/HashBuilder/Atom.HashBuilder.nuspec
+++ b/Atom/Util/HashBuilder/Atom.HashBuilder.nuspec
@@ -18,7 +18,7 @@ Check out GitHub for more docs and usage examples.</description>
       <files include="any/any/HashBuilder.cs" buildAction="Compile" copyToOutput="false" />
     </contentFiles>
     <dependencies>
-      <dependency id="Atom.CheckType" version="1.2" include="contentFiles" />
+      <dependency id="Atom.CheckType" version="1.3" include="contentFiles" />
     </dependencies>
   </metadata>
   <files>

--- a/Atom/Util/HashBuilder/HashBuilder.cs
+++ b/Atom/Util/HashBuilder/HashBuilder.cs
@@ -1,59 +1,46 @@
-﻿using System;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
+
+#nullable enable
 
 namespace Atom.Util
 {
     /// <summary>
-    /// Builds MD5 has for a combination of built-in .NET types.
+    /// Builds MD5 hash for a combination of standard .NET types.
     /// </summary>
     public class HashBuilder
     {
-        private readonly List<object> _items;
+        private readonly List<byte> _data = new();
 
         /// <summary>
-        /// Initializes a new instance.
+        /// Adds a value to a collection to be hashed.
         /// </summary>
-        public HashBuilder()
+        public HashBuilder Add(object? value)
         {
-            _items = new List<object>();
-        }
+            const int maxDataLengthToStore = 24;
 
-        /// <summary>
-        /// Adds an item to a collection to be hashed.
-        /// </summary>
-        public HashBuilder Add<T>(T item)
-        {
-            if (CheckType.IsNullable<T>())
+            var block = GetDataBlock(value);
+            if (block.Length > maxDataLengthToStore)
             {
-                // add extra boolean for nullable types
-                if (item != null)
-                {
-                    _items.Add(true);
-                    _items.Add(item);
-                }
-                else
-                {
-                    _items.Add(false);
-                }
-            }
-            else
-            {
-                _items.Add(item);
+                block = MD5.HashData(block);
             }
 
+            _data.AddRange(block);
             return this;
         }
 
         /// <summary>
-        /// Adds multiple items to a collection to be hashed.
+        /// Adds multiple values to a collection to be hashed.
         /// </summary>
-        public HashBuilder AddRange<T>(IEnumerable<T> items)
+        public HashBuilder AddMany(params object?[] values)
         {
-            foreach (var item in items)
+            foreach (var value in values)
             {
-                Add(item);
+                Add(value);
             }
 
             return this;
@@ -64,44 +51,127 @@ namespace Atom.Util
         /// </summary>
         public Guid GetHash()
         {
-            using (var ms = new MemoryStream())
+            var data = _data.ToArray();
+            var hash = MD5.HashData(data);
+            return new Guid(hash);
+        }
+
+        /// <summary>
+        /// Converts value of a known type to a binary data block.
+        /// </summary>
+        private static byte[] GetDataBlock(object? value)
+        {
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+
+            if (value == null)
             {
-                using (var bw = new BinaryWriter(ms))
+                WriteNull(bw);
+            }
+            else
+            {
+                var type = value.GetType();
+                if (CheckType.IsEnumerableOf(type, out var itemType)
+                    && type != typeof(string))
                 {
-                    foreach (var item in _items)
-                    {
-                        WriteItem(bw, item);
-                    }
-
-                    bw.Flush();
-
-                    ms.Seek(0, SeekOrigin.Begin);
-                    using (var md5 = MD5.Create())
-                    {
-                        var bytes = md5.ComputeHash(ms);
-                        return new Guid(bytes);
-                    }
+                    var dataType = WriteType(bw, itemType);
+                    WriteValues(bw, dataType, (IEnumerable)value);
                 }
+                else
+                {
+                    var dataType = WriteType(bw, type);
+                    WriteValue(bw, dataType, value);
+                }
+            }
+
+            return ms.ToArray();
+        }
+
+        /// <summary>
+        /// Writes 1-byte type code that represents <c>null</c> value.
+        /// </summary>
+        private static void WriteNull(BinaryWriter writer) => writer.Write((byte)DataType.Null);
+
+        /// <summary>
+        /// Writes 1-byte type code that represents known data type.
+        /// </summary>
+        private static DataType WriteType(BinaryWriter writer, Type type)
+        {
+            var dataType = GetKnownDataType(type);
+            writer.Write((byte)dataType);
+            return dataType;
+        }
+
+        /// <summary>
+        /// Writes 1-byte code representing a list of values, followed by 4-byte list length,
+        /// 1-byte nullability marker (whether the list contains any <c>null</c> values),
+        /// and then every list value (byte length may vary depending on the type).
+        /// </summary>
+        private static void WriteValues(BinaryWriter writer, DataType dataType, IEnumerable values)
+        {
+            writer.Write(true);
+
+            var items = values.Cast<object?>().ToList();
+            writer.Write(items.Count);
+
+            var hasNulls = items.Any(i => i == null);
+            writer.Write(hasNulls);
+
+            foreach (var item in items)
+            {
+                WriteValueBinary(writer, dataType, hasNulls, item);
             }
         }
 
         /// <summary>
-        /// Writes item of a known type to underlying binary array, before calculating a hash.
+        /// Writes 1-byte code representing single value, and then the value itself (byte length may vary depending on the type).
         /// </summary>
-        private static void WriteItem(BinaryWriter writer, object item)
+        private static void WriteValue(BinaryWriter writer, DataType dataType, object value)
         {
-            switch (item)
-            {
-                case string value: writer.Write(value); break;
-                case bool value: writer.Write(value); break;
-                case byte value: writer.Write(value); break;
-                case short value: writer.Write(value); break;
-                case int value: writer.Write(value); break;
-                case long value: writer.Write(value); break;
-                case float value: writer.Write(value); break;
-                case double value: writer.Write(value); break;
-                case decimal value: writer.Write(value); break;
+            writer.Write(false);
+            WriteValueBinary(writer, dataType, false, value);
+        }
 
+        /// <summary>
+        /// Writes value of some known data type as a binary block (byte length may vary depending on the type).
+        /// </summary>
+        private static void WriteValueBinary(BinaryWriter writer, DataType dataType, bool indicateForNullValues, object? value)
+        {
+            if (indicateForNullValues)
+            {
+                if (value == null)
+                {
+                    writer.Write(true);
+                    return;
+                }
+
+                writer.Write(false);
+            }
+
+            switch (dataType)
+            {
+                case DataType.Boolean: writer.Write((bool)value!); break;
+                case DataType.Byte: writer.Write((byte)value!); break;
+                case DataType.Int16: writer.Write((short)value!); break;
+                case DataType.Int32: writer.Write((int)value!); break;
+                case DataType.Int64: writer.Write((long)value!); break;
+                case DataType.Single: writer.Write((float)value!); break;
+                case DataType.Double: writer.Write((double)value!); break;
+                case DataType.Decimal: writer.Write((decimal)value!); break;
+                case DataType.String: writer.Write((string)value!); break;
+
+                default:
+                    throw new InvalidOperationException($"Unknown data type: {dataType}.");
+            }
+        }
+
+        /// <summary>
+        /// Writes value of a known type as a binary data block.
+        /// </summary>
+        /*private static byte[] WriteDataBlock(BinaryWriter writer, object? value)
+        {
+            switch (value)
+            {
                 case TimeSpan value:
                     writer.Write(value.Ticks);
                     break;
@@ -121,6 +191,45 @@ namespace Atom.Util
                 default:
                     throw new InvalidOperationException($"Hashing is not supported for type '{item.GetType().Name}'.");
             }
+        }*/
+
+        /// <summary>
+        /// Gets internal enum for a known data type, or throws exception saying this data type is not supported.
+        /// </summary>
+        private static DataType GetKnownDataType(Type type)
+        {
+            var nullable = Nullable.GetUnderlyingType(type);
+            if (nullable != null)
+                type = nullable;
+
+            if (type == typeof(bool)) return DataType.Boolean;
+            if (type == typeof(byte)) return DataType.Byte;
+            if (type == typeof(short)) return DataType.Int16;
+            if (type == typeof(int)) return DataType.Int32;
+            if (type == typeof(long)) return DataType.Int64;
+            if (type == typeof(float)) return DataType.Single;
+            if (type == typeof(double)) return DataType.Double;
+            if (type == typeof(decimal)) return DataType.Decimal;
+            if (type == typeof(string)) return DataType.String;
+
+            throw new InvalidOperationException($"Hashing is not supported for type '{type.Name}', use standard .NET types or collections.");
+        }
+
+        /// <summary>
+        /// Internal enum representing every known data type that can be used for hashing.
+        /// </summary>
+        private enum DataType : byte
+        {
+            Null = 0,
+            Boolean = 1,
+            Byte = 2,
+            Int16 = 3,
+            Int32 = 4,
+            Int64 = 5,
+            Single = 6,
+            Double = 7,
+            Decimal = 8,
+            String = 9,
         }
     }
 }

--- a/Atom/Util/NormalizedPath/Atom.NormalizedPath.nuspec
+++ b/Atom/Util/NormalizedPath/Atom.NormalizedPath.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Atom.NormalizedPath</id>
-    <version>0.1.0</version>
+    <version>1.0.0</version>
     <releaseNotes>Initial release.</releaseNotes>
     <tags>atom, util, normalized, relative, path, io, file</tags>
     <description>Normalized relative path that does not depend on the I/O implementation or operating system.

--- a/Atom/Util/NormalizedPath/Atom.NormalizedPath.nuspec
+++ b/Atom/Util/NormalizedPath/Atom.NormalizedPath.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Atom.NormalizedPath</id>
-    <version>0.1.2</version>
-    <releaseNotes>???</releaseNotes>
+    <version>0.1.0</version>
+    <releaseNotes>Initial release.</releaseNotes>
     <tags>atom, util, normalized, relative, path, io, file</tags>
     <description>Normalized relative path that does not depend on the I/O implementation or operating system.
 

--- a/Atom/Util/NormalizedPath/Atom.NormalizedPath.nuspec
+++ b/Atom/Util/NormalizedPath/Atom.NormalizedPath.nuspec
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>Atom.HashBuilder</id>
-    <version>1.0.3</version>
+    <id>Atom.NormalizedPath</id>
+    <version>0.1.2</version>
     <releaseNotes>???</releaseNotes>
-    <tags>atom, util, hash, md5, crc</tags>
-    <description>Builds MD5 hash for a combination of standard .NET types.
+    <tags>atom, util, normalized, relative, path, io, file</tags>
+    <description>Normalized relative path that does not depend on the I/O implementation or operating system.
 
 Add this package to your core library, so it would get the source code of this module without installing a binary dependency. Then proceed with using corresponding functionality from Atom.Util namespace, like if it was installed using binary assembly.
 
@@ -15,14 +15,11 @@ Check out GitHub for more docs and usage examples.</description>
     <icon>images/icon.png</icon>
     <license type="expression">MIT</license>
     <contentFiles>
-      <files include="any/any/HashBuilder.cs" buildAction="Compile" copyToOutput="false" />
+      <files include="any/any/NormalizedPath.cs" buildAction="Compile" copyToOutput="false" />
     </contentFiles>
-    <dependencies>
-      <dependency id="Atom.CheckType" version="1.2" include="contentFiles" />
-    </dependencies>
   </metadata>
   <files>
     <file src="../../../icon.png" target="images/" />
-    <file src="HashBuilder.cs" target="contentFiles/any/any/Atom/Util/" />
+    <file src="NormalizedPath.cs" target="contentFiles/any/any/Atom/Util/" />
   </files>
 </package>

--- a/Atom/Util/NormalizedPath/NormalizedPath.cs
+++ b/Atom/Util/NormalizedPath/NormalizedPath.cs
@@ -40,14 +40,14 @@ namespace Atom.Util
             if (!path.StartsWith("/", StringComparison.Ordinal))
                 throw new ArgumentException($"Path '{path}' is expected to start with '/'." + hint, nameof(path));
 
-            void CheckInvalidCharacter(string invalid)
+            void CheckInvalidCharacters(string invalid)
             {
                 if (path.Contains(invalid))
                     throw new ArgumentException($"Path '{path}' is not expected to contain '{invalid}'." + hint, nameof(path));
             }
 
             foreach (var invalid in new[] { "//", "\\", ":", "*", "?", "\"", "<", ">", "|" })
-                CheckInvalidCharacter(invalid);
+                CheckInvalidCharacters(invalid);
 
             RawPath = path;
         }
@@ -112,8 +112,9 @@ namespace Atom.Util
         public NormalizedPath AppendFile(string fileName)
         {
             EnsureIsDirectory();
-            if (!fileName.EndsWith("/", StringComparison.Ordinal))
+            if (fileName.EndsWith("/", StringComparison.Ordinal))
                 throw new ArgumentException($"The provided value '{fileName}' more looks like a directory rather than file name.", nameof(fileName));
+
             var pathToAdd = fileName.Trim('/');
             return new NormalizedPath(RawPath + pathToAdd);
         }

--- a/Atom/Util/NormalizedPath/NormalizedPath.cs
+++ b/Atom/Util/NormalizedPath/NormalizedPath.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+#nullable enable
+
+namespace Atom.Util
+{
+    /// <summary>
+    /// Helper methods for working with I/O and local files.
+    /// </summary>
+    public static class NormalizedPath
+    {
+        /// <summary>
+        /// Makes sure that specified path was absolute (i.e. non-relative),
+        /// and throws <see cref="InvalidOperationException"/> otherwise.
+        /// </summary>
+        public static void EnsureAbsolute(string path)
+        {
+            if (!Path.IsPathFullyQualified(path))
+                throw new InvalidOperationException($"Path should be absolute: {path}");
+        }
+
+        /// <summary>
+        /// Scans specified path with various parameters. Can search for files and/or directories,
+        /// and use custom predicate functions for whether an item (file or directory) should be returned,
+        /// as well as whether the search should continue recursively.
+        /// </summary>
+        /// <param name="pathToScan">Base path to scan. All result items will get their relative paths based on this location.</param>
+        /// <param name="recursive">Whether scan should continue recursively, or be limited to the specified directory only</param>
+        /// <param name="includeFiles">Whether files should be included as result items</param>
+        /// <param name="includeDirectories">Whether directories should be included as result items</param>
+        /// <param name="matchPredicate">
+        /// A function determining whether an item (file or directory) should be included into result or ignored, e.g.
+        /// <code>
+        /// // find files by extension (case-insensitive)
+        /// matchPredicate: item =>
+        ///     String.Equals(Path.GetExtension(item.Name), ".txt", StringComparison.OrdinalIgnoreCase)
+        /// </code>
+        /// </param>
+        /// <param name="scanPredicate">
+        /// A function determining whether the search should continue for this directory, e.g.
+        /// <code>
+        /// // do not search in certain folders
+        /// scanPredicate: item =>
+        ///     item.Name != ".git"
+        ///     && item.Name != "bin"
+        ///     && item.Name != "obj"
+        ///     && item.Name != "node_modules"
+        /// </code>
+        /// Not used when <paramref name="recursive"/> is <c>false</c>.
+        /// </param>
+        /// <returns>A list of items (files and directories) that were found</returns>
+        public static List<PathItem> Scan(
+            string pathToScan,
+            bool recursive = true,
+            bool includeFiles = true,
+            bool includeDirectories = true,
+            Func<PathItem, bool>? matchPredicate = null,
+            Func<PathItem, bool>? scanPredicate = null)
+        {
+            EnsureAbsolute(pathToScan);
+            var result = new List<PathItem>();
+            ScanPath("/", pathToScan, result, recursive, includeFiles, includeDirectories, matchPredicate, scanPredicate);
+            return result;
+        }
+
+        private static void ScanPath(
+            string relativePath,
+            string currentPath,
+            List<PathItem> result,
+            bool recursive,
+            bool includeFiles,
+            bool includeDirectories,
+            Func<PathItem, bool>? matchPredicate,
+            Func<PathItem, bool>? scanPredicate)
+        {
+            if (includeFiles)
+            {
+                foreach (var file in Directory.GetFiles(currentPath, "*", SearchOption.TopDirectoryOnly))
+                {
+                    var fileName = Path.GetFileName(file);
+                    var fileItem = new PathItem
+                    {
+                        Name = fileName,
+                        IsDirectory = false,
+                        AbsolutePath = file,
+                        RelativePath = $"{relativePath}{fileName}"
+                    };
+
+                    if (matchPredicate == null || matchPredicate.Invoke(fileItem))
+                    {
+                        result.Add(fileItem);
+                    }
+                }
+            }
+
+            if (includeDirectories || recursive)
+            {
+                foreach (var dir in Directory.GetDirectories(currentPath, "*", SearchOption.TopDirectoryOnly))
+                {
+                    var dirName = Path.GetFileName(dir);
+                    var dirItem = new PathItem
+                    {
+                        Name = dirName,
+                        IsDirectory = true,
+                        AbsolutePath = dir,
+                        RelativePath = $"{relativePath}{dirName}/"
+                    };
+
+                    if (includeDirectories)
+                    {
+                        if (matchPredicate == null || matchPredicate.Invoke(dirItem))
+                        {
+                            result.Add(dirItem);
+                        }
+                    }
+
+                    if (recursive)
+                    {
+                        if (scanPredicate == null || scanPredicate.Invoke(dirItem))
+                        {
+                            ScanPath(dirItem.RelativePath, dir, result, recursive, includeFiles, includeDirectories, matchPredicate, scanPredicate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Atom/Util/PathUtil/Atom.PathUtil.nuspec
+++ b/Atom/Util/PathUtil/Atom.PathUtil.nuspec
@@ -2,9 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Atom.PathUtil</id>
-    <version>1.0.0</version>
-    <releaseNotes>Initial release with a 'Scan' method.</releaseNotes>
-    <tags>atom, util, io, file, path</tags>
+    <version>1.0.2</version>
+    <releaseNotes>???</releaseNotes>
+    <tags>atom, util, path, io, file</tags>
     <description>Helper methods for working with I/O and local files.
 
 Add this package to your core library, so it would get the source code of this module without installing a binary dependency. Then proceed with using corresponding functionality from Atom.Util namespace, like if it was installed using binary assembly.

--- a/Atom/Util/PathUtil/Atom.PathUtil.nuspec
+++ b/Atom/Util/PathUtil/Atom.PathUtil.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Atom.PathUtil</id>
-    <version>1.0.2</version>
-    <releaseNotes>???</releaseNotes>
+    <version>1.1.0</version>
+    <releaseNotes>Uses NormalizedPath to represent relative path.</releaseNotes>
     <tags>atom, util, path, io, file</tags>
     <description>Helper methods for working with I/O and local files.
 
@@ -17,6 +17,9 @@ Check out GitHub for more docs and usage examples.</description>
     <contentFiles>
       <files include="any/any/PathUtil.cs" buildAction="Compile" copyToOutput="false" />
     </contentFiles>
+    <dependencies>
+      <dependency id="NormalizedPath" version="1.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="../../../icon.png" target="images/" />

--- a/Atom/Util/PathUtil/PathUtil.cs
+++ b/Atom/Util/PathUtil/PathUtil.cs
@@ -35,7 +35,7 @@ namespace Atom.Util
         /// <code>
         /// // find files by extension (case-insensitive)
         /// matchPredicate: item =>
-        ///     String.Equals(Path.GetExtension(item.Name), ".txt", StringComparison.OrdinalIgnoreCase));
+        ///     String.Equals(Path.GetExtension(item.Name), ".txt", StringComparison.OrdinalIgnoreCase)
         /// </code>
         /// </param>
         /// <param name="scanPredicate">
@@ -46,7 +46,7 @@ namespace Atom.Util
         ///     item.Name != ".git"
         ///     && item.Name != "bin"
         ///     && item.Name != "obj"
-        ///     && item.Name != "node_modules");
+        ///     && item.Name != "node_modules"
         /// </code>
         /// Not used when <paramref name="recursive"/> is <c>false</c>.
         /// </param>

--- a/Atom/Util/PathUtil/PathUtil.cs
+++ b/Atom/Util/PathUtil/PathUtil.cs
@@ -148,6 +148,6 @@ namespace Atom.Util
         /// <summary>
         /// Relative path, e.g. "/Files/MyFile.txt".
         /// </summary>
-        public string RelativePath { get; set; } = null!;
+        public NormalizedPath RelativePath { get; set; } = null!;
     }
 }

--- a/Atom/Util/SlnFile/Atom.SlnFile.nuspec
+++ b/Atom/Util/SlnFile/Atom.SlnFile.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Atom.SlnFile</id>
-    <version>1.0.1</version>
-    <releaseNotes>More accurate header parsing.</releaseNotes>
+    <version>1.0.2</version>
+    <releaseNotes>Minor formatting update.</releaseNotes>
     <tags>atom, util, vs, studio, sln, solution, file</tags>
     <description>Provides methods for parsing and creating Visual Studio Solution (*.sln) files.
 

--- a/Atom/Util/SlnFile/SlnFile.cs
+++ b/Atom/Util/SlnFile/SlnFile.cs
@@ -249,12 +249,12 @@ namespace Atom.Util
                 throw new ArgumentNullException(nameof(header.MinimumVisualStudioVersion));
 
             return new()
-        {
-            $"Microsoft Visual Studio Solution File, Format Version {header.FormatVersion}",
-            $"# {header.CurrentVisualStudioVersion}",
-            $"VisualStudioVersion = {header.FullVisualStudioVersion}",
-            $"MinimumVisualStudioVersion = {header.MinimumVisualStudioVersion}"
-        };
+            {
+                $"Microsoft Visual Studio Solution File, Format Version {header.FormatVersion}",
+                $"# {header.CurrentVisualStudioVersion}",
+                $"VisualStudioVersion = {header.FullVisualStudioVersion}",
+                $"MinimumVisualStudioVersion = {header.MinimumVisualStudioVersion}"
+            };
         }
 
         private static List<string> RenderProject(SlnFileProject project)

--- a/Modules.json
+++ b/Modules.json
@@ -5,7 +5,7 @@
     "Tags": "async, for, foreach",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "613cff9c-f0ab-9e63-e57e-24218cbb1eba"
+    "SourceHash": "3f110ddb-848c-0a05-76a8-c6acf0ff6558"
   },
   "AWSClient": {
     "Category": "AWS",
@@ -13,7 +13,7 @@
     "Tags": "options, client, credentials, profile",
     "Version": "1.1.5",
     "ReleaseNotes": "Adjusted AWS SDK version to provide better compatibility.",
-    "SourceHash": "4b4e6a44-0091-2996-1ad4-d2e13c1c015f",
+    "SourceHash": "f43b01de-173d-7c8c-62e3-190db1ddcd24",
     "DependsOn": [
       "AWSSDK.Core 3.3.100"
     ]
@@ -24,7 +24,7 @@
     "Tags": "queue, client",
     "Version": "1.1.6",
     "ReleaseNotes": "Adjusted AWS SDK version to provide better compatibility.",
-    "SourceHash": "183bbd56-a57b-802d-a8dd-841b7f222e71",
+    "SourceHash": "ff5847cd-9fe9-35bb-ce64-7901fb2d7d28",
     "DependsOn": [
       "Atom.AsyncUtil 1.0",
       "Atom.AWSClient 1.1",
@@ -38,7 +38,7 @@
     "Tags": "blob, client",
     "Version": "1.3.0",
     "ReleaseNotes": "Added connection via Azure managed identities.",
-    "SourceHash": "b9e16377-b746-5e71-28c4-366744ff57ef",
+    "SourceHash": "15332f3c-2fd8-0083-4d16-e0444a94b9d9",
     "DependsOn": [
       "Atom.AzureClient 1.1",
       "Azure.Storage.Blobs 12.6"
@@ -50,7 +50,7 @@
     "Tags": "options, client, credentials, profile",
     "Version": "1.1.1",
     "ReleaseNotes": "Adjusted Azure SDK version to provide better compatibility.",
-    "SourceHash": "73e56618-5e9b-042a-da43-f21cfc2945a1",
+    "SourceHash": "e57185b9-2d56-b7e4-d36e-c5c5b0daf016",
     "DependsOn": [
       "Azure.Identity 1.3"
     ]
@@ -61,7 +61,7 @@
     "Tags": "queue, client",
     "Version": "1.3.1",
     "ReleaseNotes": "Adjusted Azure SDK version to provide better compatibility.",
-    "SourceHash": "d7f5619b-fe60-1ecf-7947-d233f806e6a9",
+    "SourceHash": "c1f18938-25f3-4b35-315c-7df43d5f3f3b",
     "DependsOn": [
       "Atom.AsyncUtil 1.0",
       "Atom.AzureClient 1.1",
@@ -74,7 +74,7 @@
     "Tags": "base64, base64url, rfc4648",
     "Version": "1.0.3",
     "ReleaseNotes": "Minor optimization.",
-    "SourceHash": "066d464d-3658-2288-78c7-fa0faea4cc07"
+    "SourceHash": "519359ea-113b-5bf6-fac8-00e04d0611cd"
   },
   "Batch": {
     "Category": "Util",
@@ -82,7 +82,7 @@
     "Tags": "batch, collection, list, enumerable",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "afbfae75-c663-5efa-7b9b-ddce683be754"
+    "SourceHash": "7c03dc56-a05a-0b08-cffc-592901efe337"
   },
   "CheckType": {
     "Category": "Util",
@@ -90,7 +90,7 @@
     "Tags": "check, type, nullable, enum, enumerable",
     "Version": "1.3.0",
     "ReleaseNotes": "Added IsEnumerableOf<T>() method.",
-    "SourceHash": "f7004af3-ee31-f11e-49c5-61ebf6b0bfe6"
+    "SourceHash": "468a1c1d-3f4d-62ff-5449-edf2a5002a1a"
   },
   "CommaList": {
     "Category": "Util",
@@ -98,7 +98,7 @@
     "Tags": "comma, separated, list",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "540eed67-6dab-f7ee-c39e-5c446ea23e67"
+    "SourceHash": "4457e88d-6fdd-f6e1-f06f-5d5d862f90b3"
   },
   "HashBuilder": {
     "Category": "Util",
@@ -106,7 +106,7 @@
     "Tags": "hash, md5, crc",
     "Version": "1.0.3",
     "ReleaseNotes": "???",
-    "SourceHash": "da869cbf-092c-2bdb-5a72-3168093b4c35",
+    "SourceHash": "c29f067d-1689-b461-a0b2-1908ec22fedd",
     "DependsOn": [
       "Atom.CheckType 1.3"
     ]
@@ -115,9 +115,9 @@
     "Category": "Util",
     "Description": "Normalized relative path that does not depend on the I/O implementation or operating system.",
     "Tags": "normalized, relative, path, io, file",
-    "Version": "0.1.2",
-    "ReleaseNotes": "???",
-    "SourceHash": "fb30092b-d979-af83-7d7c-c19447164137"
+    "Version": "0.1.0",
+    "ReleaseNotes": "Initial release.",
+    "SourceHash": "13488d7f-5a50-6516-5a62-b6cc796bd7de"
   },
   "Parse": {
     "Category": "Util",
@@ -125,7 +125,7 @@
     "Tags": "string, parse, as, convert",
     "Version": "1.2.1",
     "ReleaseNotes": "Published with updated dependency.",
-    "SourceHash": "81039f53-ed37-89a9-5542-49de6e5255d0",
+    "SourceHash": "b0096b20-c544-808d-70d9-8c18a5834425",
     "DependsOn": [
       "Atom.CheckType 1.2",
       "Atom.TypeName 1.0"
@@ -137,7 +137,7 @@
     "Tags": "path, io, file",
     "Version": "1.0.2",
     "ReleaseNotes": "???",
-    "SourceHash": "9f1c769d-7163-bc33-dab3-266b11581d42"
+    "SourceHash": "cfdcf5c5-9f77-db63-4043-26d9a6bc3668"
   },
   "RunProcess": {
     "Category": "Util",
@@ -145,7 +145,7 @@
     "Tags": "run, process, external",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "ae04e15f-f239-63cd-481a-c384f87c59c6"
+    "SourceHash": "5676566f-0922-c92e-1382-cdfd9a5710fc"
   },
   "SlnFile": {
     "Category": "Util",
@@ -153,7 +153,7 @@
     "Tags": "vs, studio, sln, solution, file",
     "Version": "1.0.1",
     "ReleaseNotes": "More accurate header parsing.",
-    "SourceHash": "6a09c39d-7677-8764-278f-ae757e811daa",
+    "SourceHash": "cc0d8179-f6ff-d921-af86-658ac98cf503",
     "DependsOn": [
       "Atom.VSConstants 1.0"
     ]
@@ -164,7 +164,7 @@
     "Tags": "type, name, keyword, friendly, readable",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "7e58fbac-45fb-5516-c69e-77ac36c12e56"
+    "SourceHash": "2c400005-6718-0dbb-6436-18969ad41dfb"
   },
   "VSConstants": {
     "Category": "Util",
@@ -172,7 +172,7 @@
     "Tags": "vs, msbuild, constants, type, guids",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "e6ca9925-7b69-0a25-ffa4-c373d7c4766a"
+    "SourceHash": "965a7723-6937-f9f8-7cc2-f0532f667ecf"
   },
   "XConsole": {
     "Category": "Util",
@@ -180,7 +180,7 @@
     "Tags": "console, colored, output",
     "Version": "1.3.3",
     "ReleaseNotes": "PressAnyKey() will not output pressed key.",
-    "SourceHash": "d09f5dd4-f795-c245-fe97-684afe16a488"
+    "SourceHash": "4b4e5b13-dd73-385c-82cb-679b10aadb95"
   },
   "XDoc": {
     "Category": "Util",
@@ -188,6 +188,6 @@
     "Tags": "xml, doc",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "c0471767-24b9-8d3f-fd93-8f0b32ddf857"
+    "SourceHash": "efa7526c-1f79-3d23-1aed-713683ddc19f"
   }
 }

--- a/Modules.json
+++ b/Modules.json
@@ -86,11 +86,11 @@
   },
   "CheckType": {
     "Category": "Util",
-    "Description": "Checks multiple criteria for built-in .NET types (is nullable, is enum, etc.)",
-    "Tags": "check, type, nullable, enum",
-    "Version": "1.2.0",
-    "ReleaseNotes": "GetKeyword<T>() was moved to a different module named Atom.TypeName.",
-    "SourceHash": "c8db5703-1a84-468a-8a0e-f29ae5e7d5e6"
+    "Description": "Provides various checks for built-in .NET types (is nullable, is enum, is enumerable etc.)",
+    "Tags": "check, type, nullable, enum, enumerable",
+    "Version": "1.3.0",
+    "ReleaseNotes": "Added IsEnumerableOf<T>() method.",
+    "SourceHash": "f7004af3-ee31-f11e-49c5-61ebf6b0bfe6"
   },
   "CommaList": {
     "Category": "Util",
@@ -102,14 +102,22 @@
   },
   "HashBuilder": {
     "Category": "Util",
-    "Description": "Builds MD5 has for a combination of built-in .NET types.",
+    "Description": "Builds MD5 hash for a combination of standard .NET types.",
     "Tags": "hash, md5, crc",
-    "Version": "1.0.2",
-    "ReleaseNotes": "Published with updated dependency.",
-    "SourceHash": "7b7a555e-8b0b-1cbe-94b5-b4d490dd3846",
+    "Version": "1.0.3",
+    "ReleaseNotes": "???",
+    "SourceHash": "da869cbf-092c-2bdb-5a72-3168093b4c35",
     "DependsOn": [
-      "Atom.CheckType 1.2"
+      "Atom.CheckType 1.3"
     ]
+  },
+  "NormalizedPath": {
+    "Category": "Util",
+    "Description": "Normalized relative path that does not depend on the I/O implementation or operating system.",
+    "Tags": "normalized, relative, path, io, file",
+    "Version": "0.1.2",
+    "ReleaseNotes": "???",
+    "SourceHash": "fb30092b-d979-af83-7d7c-c19447164137"
   },
   "Parse": {
     "Category": "Util",
@@ -126,10 +134,10 @@
   "PathUtil": {
     "Category": "Util",
     "Description": "Helper methods for working with I/O and local files.",
-    "Tags": "io, file, path",
-    "Version": "1.0.0",
-    "ReleaseNotes": "Initial release with a 'Scan' method.",
-    "SourceHash": "3dc0fedb-b77a-141e-9775-0a6c3edfa4e1"
+    "Tags": "path, io, file",
+    "Version": "1.0.2",
+    "ReleaseNotes": "???",
+    "SourceHash": "9f1c769d-7163-bc33-dab3-266b11581d42"
   },
   "RunProcess": {
     "Category": "Util",

--- a/Modules.json
+++ b/Modules.json
@@ -117,7 +117,7 @@
     "Tags": "normalized, relative, path, io, file",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "0a8d7fb4-8420-effc-a116-9c61c41a2e65"
+    "SourceHash": "cbf486bb-4b1d-b5f6-6297-ec067ade36a9"
   },
   "Parse": {
     "Category": "Util",

--- a/Modules.json
+++ b/Modules.json
@@ -117,7 +117,7 @@
     "Tags": "normalized, relative, path, io, file",
     "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
-    "SourceHash": "13488d7f-5a50-6516-5a62-b6cc796bd7de"
+    "SourceHash": "0a8d7fb4-8420-effc-a116-9c61c41a2e65"
   },
   "Parse": {
     "Category": "Util",
@@ -137,7 +137,7 @@
     "Tags": "path, io, file",
     "Version": "1.1.0",
     "ReleaseNotes": "Uses NormalizedPath to represent relative path.",
-    "SourceHash": "cfdcf5c5-9f77-db63-4043-26d9a6bc3668",
+    "SourceHash": "68607ab5-e33e-a925-ed96-dde5ae960531",
     "DependsOn": [
       "NormalizedPath 1.0"
     ]

--- a/Modules.json
+++ b/Modules.json
@@ -104,9 +104,9 @@
     "Category": "Util",
     "Description": "Builds MD5 hash for a combination of standard .NET types.",
     "Tags": "hash, md5, crc",
-    "Version": "1.0.3",
-    "ReleaseNotes": "???",
-    "SourceHash": "c29f067d-1689-b461-a0b2-1908ec22fedd",
+    "Version": "1.1.0",
+    "ReleaseNotes": "New hashing algorithm that considers data types, nullability and avoids collisions.",
+    "SourceHash": "331b73ee-0fc6-a3dc-c535-af2109b56794",
     "DependsOn": [
       "Atom.CheckType 1.3"
     ]
@@ -115,7 +115,7 @@
     "Category": "Util",
     "Description": "Normalized relative path that does not depend on the I/O implementation or operating system.",
     "Tags": "normalized, relative, path, io, file",
-    "Version": "0.1.0",
+    "Version": "1.0.0",
     "ReleaseNotes": "Initial release.",
     "SourceHash": "13488d7f-5a50-6516-5a62-b6cc796bd7de"
   },
@@ -135,9 +135,12 @@
     "Category": "Util",
     "Description": "Helper methods for working with I/O and local files.",
     "Tags": "path, io, file",
-    "Version": "1.0.2",
-    "ReleaseNotes": "???",
-    "SourceHash": "cfdcf5c5-9f77-db63-4043-26d9a6bc3668"
+    "Version": "1.1.0",
+    "ReleaseNotes": "Uses NormalizedPath to represent relative path.",
+    "SourceHash": "cfdcf5c5-9f77-db63-4043-26d9a6bc3668",
+    "DependsOn": [
+      "NormalizedPath 1.0"
+    ]
   },
   "RunProcess": {
     "Category": "Util",
@@ -151,9 +154,9 @@
     "Category": "Util",
     "Description": "Provides methods for parsing and creating Visual Studio Solution (*.sln) files.",
     "Tags": "vs, studio, sln, solution, file",
-    "Version": "1.0.1",
-    "ReleaseNotes": "More accurate header parsing.",
-    "SourceHash": "cc0d8179-f6ff-d921-af86-658ac98cf503",
+    "Version": "1.0.2",
+    "ReleaseNotes": "Minor formatting update.",
+    "SourceHash": "825cc580-fe92-7478-35cb-83c02455a174",
     "DependsOn": [
       "Atom.VSConstants 1.0"
     ]

--- a/pack.bat
+++ b/pack.bat
@@ -17,6 +17,7 @@ dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\Batch\Atom.Batch.nuspec --no-bui
 dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\CheckType\Atom.CheckType.nuspec --no-build --output nuget
 dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\CommaList\Atom.CommaList.nuspec --no-build --output nuget
 dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\HashBuilder\Atom.HashBuilder.nuspec --no-build --output nuget
+dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\NormalizedPath\Atom.NormalizedPath.nuspec --no-build --output nuget
 dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\Parse\Atom.Parse.nuspec --no-build --output nuget
 dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\PathUtil\Atom.PathUtil.nuspec --no-build --output nuget
 dotnet pack Atom\Atom.csproj /p:NuspecFile=Util\RunProcess\Atom.RunProcess.nuspec --no-build --output nuget


### PR DESCRIPTION
- CheckType 1.2.0 → 1.3.0
  - Converted to nullable
  - Added IsEnumerableOf<T>() method
  - Added more tests

- HashBuilder 1.0.2 → 1.1.0
  - Converted to nullable
  - New hashing algorithm that considers data types, nullability and avoids collisions
  - Added more tests

- NormalizedPath 1.0.0
  - Initial release

- PathUtil 1.0.0 → 1.1.0
  - Uses NormalizedPath to represent relative path

- SlnFile 1.0.1 → 1.0.2
  - Minor formatting update
